### PR TITLE
rename repository name oauth2_proxy to oauth2-proxy

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,7 +1,7 @@
 c = Chef::Config[:file_cache_path]
 name = "oauth2_proxy-v#{node["oauth2_proxy"]['version']}.linux-amd64.go#{node["oauth2_proxy"]['goversion']}.tar.gz"
 remote_file "#{c}/#{name}" do
-  source "https://github.com/oauth2_proxy/oauth2_proxy/releases/download/v#{node["oauth2_proxy"]['version']}/#{name}"
+  source "https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v#{node["oauth2_proxy"]['version']}/#{name}"
   notifies :run, 'execute[install_oauth2_proxy]'
 end
 


### PR DESCRIPTION
hi @pyama86 ! The repository name https://github.com/oauth2_proxy/oauth2_proxy seems to have been changed to https://github.com/oauth2-proxy/oauth2-proxy (The underscore has been changed to a hyphen) .